### PR TITLE
Update shopping_list_with_grocy.py

### DIFF
--- a/custom_components/shopping_list_with_grocy/apis/shopping_list_with_grocy.py
+++ b/custom_components/shopping_list_with_grocy/apis/shopping_list_with_grocy.py
@@ -68,6 +68,10 @@ class ShoppingListWithGrocyApi:
         return s.translate(vowel_char_map)
 
     def slugify(self, s):
+        if s and s[-2] == '  ':
+            s = s[:-2] + '_3'
+        if s and s[-1] == ' ':
+            s = s[:-1] + '_2'
         s = s.lower().strip()
         s = re.sub(r"[^\w\s-]", "", s)
         s = re.sub(r"[\s_-]+", "_", s)


### PR DESCRIPTION
This fixes the issue #11  where the product name contains either one or two trailing spaces. Although the sensors were being created correctly, the data for the second sensor overwrote the first. This PR creates a distinct sensor name for the second sensor