### PR TITLE
Update config_flow.py

### DIFF
--- a/custom_components/shopping_list_with_grocy/config_flow.py
+++ b/custom_components/shopping_list_with_grocy/config_flow.py
@@ -67,7 +67,7 @@ class ShoppingListWithGrocyOptionsConfigFlow(config_entries.OptionsFlow):  # typ
                     vol.Optional(
                         "image_download_size",
                         default=self.options.get("image_download_size", 100),
-                    ): vol.All(cv.positive_int, vol.In([0, 100, 200, 400])),
+                    ): vol.All(cv.positive_int, vol.In([0, 25, 50, 75, 100, 125, 150, 175, 200])),
                     vol.Optional(
                         "adding_products_in_sensor",
                         default=self.options.get("adding_products_in_sensor", False),
@@ -133,7 +133,7 @@ class ShoppingListWithGrocyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Optional(
                         "image_download_size",
                         default=100,
-                    ): vol.All(cv.positive_int, vol.In([0, 100, 200, 400])),
+                    ): vol.All(cv.positive_int, vol.In([0, 25, 50, 75, 100, 125, 150, 175, 200])),
                     vol.Optional(
                         "adding_products_in_sensor", default=False
                     ): cv.boolean,


### PR DESCRIPTION
An image size of 400px can exceed the maximum sensor data size in HA. Have changed the download options sizes to allow a maximum image size of 200px. Have also increased the number of available options for extra flexibility.